### PR TITLE
Fixes #24448 #25153 templateVars and templateOptions set to [] on reset

### DIFF
--- a/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
+++ b/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
@@ -350,8 +350,8 @@ class TransportBuilder
     {
         $this->messageData = [];
         $this->templateIdentifier = null;
-        $this->templateVars = null;
-        $this->templateOptions = null;
+        $this->templateVars = [];
+        $this->templateOptions = [];
         return $this;
     }
 


### PR DESCRIPTION
### Summary
     - Fixes bug at checkout where payment is taken but error is thrown
     - Fixes issues #24448 #25153

### Description
Fixes an issue with when using default settings or a third party SMTP plugin for Mail. The magento/framework/Mail/Template/TransportBuilder.php reset() function incorrectly sets templateVars and templateOptions to null instead of an empty array.

### Fixed Issues
1. #24448, #25153

### Manual testing scenarios (*)

#### Preconditions (*)
1. Magento 2.3.3
2. PHP >=7.2

#### Steps to reproduce (*)
1. Add product to basket and checkout via Braintree 

#### Expected result (*)
1. I would expect for the payment to go through and the user to be taken to the success page

#### Actual result (*)
1. Payment is taken, but an error message is thrown, if you expect console you will see the payment-information request returns a 500 error response:

Network error:
`{"messages":{"error":[{"code":500,"message":"Server internal error. See details in report api\/1097618965122"}]}}`

Report Api log:
`"Fatal Error: 'Uncaught TypeError: Argument 1 passed to Magento\\Email\\Model\\Template::setVars() must be of the type array, null given, called in \/var\/www\/vhosts\/www.magento2site.co.uk\/htdocs\/releases\/20191126103620\/vendor\/magento\/framework\/Mail\/Template\/TransportBuilder.php on line 368 and defined in \/var\/www\/vhosts\/www.magento2site.co.uk\/htdocs\/releases\/20191126103620\/vendor\/magento\/module-email\/Model\/Template.php:403\nStack trace:\n#0 \/var\/www\/vhosts\/www.magento2site.co.uk\/htdocs\/releases\/20191126103620\/vendor\/magento\/framework\/Mail\/Template\/TransportBuilder.php(368): Magento\\Email\\Model\\Template->setVars(NULL)\n#1 \/var\/www\/vhosts\/www.magento2site.co.uk\/htdocs\/releases\/20191126103620\/vendor\/magento\/framework\/Mail\/Template\/TransportBuilder.php(380): Magento\\Framework\\Mail\\Template\\TransportBuilder->getTemplate()\n#2 \/var\/www\/vhosts\/www.magento2site.co.uk\/htdocs\/releases\/20191126103620\/vendor\/magento\/framework\/Mail\/Template\/TransportBuilder.php(337): Magento\\Framework\\Mail\\Template\\TransportBuilder->pre' in '\/var\/www\/vhosts\/www.magento2site.co.uk\/htdocs\/releases\/20191126103620\/vendor\/magento\/module-email\/Model\/Template.php' on line 403"`
